### PR TITLE
Rb/date url params

### DIFF
--- a/src/app/development/permits/PermitsIndex.js
+++ b/src/app/development/permits/PermitsIndex.js
@@ -14,6 +14,7 @@ class PermitsIndex extends React.Component {
     let currentUrlParams = new URLSearchParams(window.location.search);
 
     if (currentUrlParams.has('rangeFrom') && currentUrlParams.has('rangeThrough')) {
+
       if (isNaN(currentUrlParams.get('rangeFrom')) || isNaN(currentUrlParams.get('rangeThrough'))) {
         defaultExtent = [
           this.props.initialBrushExtent[0],
@@ -26,7 +27,9 @@ class PermitsIndex extends React.Component {
           let newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + `?${currentUrlParams}`;
           window.history.pushState({path: newurl}, '', newurl);
         }
+
       } else {
+
         const rangeOverhead = timeDay.count(currentUrlParams.get('rangeThrough'), this.props.spanUpperLimit);
         const rangeUnderhead = timeDay.count(this.props.spanLowerLimit, currentUrlParams.get('rangeFrom'));
 
@@ -42,6 +45,12 @@ class PermitsIndex extends React.Component {
           ];  
         }
       }
+
+    } else if (currentUrlParams.has('range') && currentUrlParams.get('range').toLowerCase() === 'oneyearback') {
+      defaultExtent = [
+        timeMonth.offset(timeDay.floor(new Date()), -12).getTime(),
+        timeDay.floor(new Date()).getTime(),
+      ];
       
     } else {
       defaultExtent = [
@@ -52,6 +61,7 @@ class PermitsIndex extends React.Component {
 
     currentUrlParams.set('rangeFrom', defaultExtent[0]);
     currentUrlParams.set('rangeThrough', defaultExtent[1]);
+    currentUrlParams.delete('range');
 
     if (history.pushState) {
       let newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + `?${currentUrlParams}`;
@@ -110,11 +120,11 @@ class PermitsIndex extends React.Component {
 
 PermitsIndex.defaultProps = {
   initialBrushExtent: [
-    timeWeek.offset(timeDay.floor(new Date()), -8).getTime(),
+    timeMonth.offset(timeDay.floor(new Date()), -1).getTime(),
     timeDay.floor(new Date()).getTime(),
   ], 
   spanUpperLimit: timeDay.floor(new Date()).getTime(),
-  spanLowerLimit: timeDay.floor(new Date(Date.UTC(1999, 6, 1))).getTime(),
+  spanLowerLimit: timeDay.floor(new Date(Date.UTC(1999, 0, 1))).getTime(),
 };
 
 export default PermitsIndex;

--- a/src/app/development/permits/PermitsIndex.js
+++ b/src/app/development/permits/PermitsIndex.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { timeDay, timeWeek } from 'd3-time';
+import { timeDay, timeWeek, timeMonth } from 'd3-time';
 import PermitsTableWrapper from './PermitsTableWrapper';
 import TimeSlider from '../volume/TimeSlider';
 import ErrorBoundary from '../../../shared/ErrorBoundary';
@@ -7,17 +7,41 @@ import ErrorBoundary from '../../../shared/ErrorBoundary';
 
 
 class PermitsIndex extends React.Component {
-  constructor() {
-    super();
-    const now = timeDay.floor(new Date());
-    this.initialBrushExtent = [
-      timeWeek.offset(now, -4).getTime(),
-      now.getTime(),
-    ];
+  constructor(props) {
+    super(props);
+    // const now = timeDay.floor(new Date());
+    // this.initialBrushExtent = [
+    //   this.props.initialBrushExtent,
+    //   now.getTime(),
+    // ];
+    console.log(props);
     this.state = {
-      timeSpan: this.initialBrushExtent,
+      timeSpan: this.props.initialBrushExtent,
     };
   }
+
+  // onDateRangeChange(filter) {
+  //   let newParams = '';
+  //   if (filter.length > 0) {
+  //     newParams = `${filter
+  //       .map(filterObj => `${filterObj.id}=${filterObj.value}`)
+  //       .join('&')}`;
+  //   }
+  //   window
+  //     .history
+  //     .pushState(
+  //       {},
+  //       '',
+  //       `${location.pathname}${newParams.length > 0 ? '?' : ''}${newParams}${location.hash}`
+  //     );
+  //   this.setState({
+  //     filtered: filter,
+  //   });
+  // }
+
+  // componentDidMount() {
+
+  // }
 
   render() {
     return (
@@ -32,7 +56,8 @@ class PermitsIndex extends React.Component {
             onBrushEnd={newExtent => this.setState({
               timeSpan: newExtent,
             })}
-            defaultBrushExtent={this.initialBrushExtent}
+            defaultBrushExtent={this.state.timeSpan}
+            xSpan={2}
           />
           <PermitsTableWrapper
             // Defaults are fine for now
@@ -45,5 +70,12 @@ class PermitsIndex extends React.Component {
     );
   }
 }
+
+PermitsIndex.defaultProps = {
+  initialBrushExtent: [
+    timeMonth.offset(timeDay.floor(new Date()), -3).getTime(),
+    timeDay.floor(new Date()).getTime(),
+  ], // today and today minus 3 months
+};
 
 export default PermitsIndex;

--- a/src/app/development/trc/TRCDataTable.js
+++ b/src/app/development/trc/TRCDataTable.js
@@ -12,7 +12,7 @@ class TRCDataTable extends React.Component {
     super();
     const now = timeDay.floor(new Date());
     this.initialBrushExtent = [
-      timeMonth.offset(now, -12).getTime(),
+      timeMonth.offset(now, -6).getTime(),
       now.getTime(),
     ];
     this.state = {
@@ -28,7 +28,7 @@ class TRCDataTable extends React.Component {
             timeSpan: newExtent,
           })}
           defaultBrushExtent={this.initialBrushExtent}
-          xSpan={3}
+          xSpan={2}
         />
         <PermitsTableWrapper
           after={this.state.timeSpan[0]}

--- a/src/app/development/volume/TimeSlider.js
+++ b/src/app/development/volume/TimeSlider.js
@@ -5,71 +5,170 @@ import moment from 'moment';
 import { timeDay, timeWeek, timeMonth, timeYear } from 'd3-time';
 import ErrorBoundary from '../../../shared/ErrorBoundary';
 
-function spanOfYears(numYears) {
-  return [
-    timeYear.offset(timeDay.floor(new Date()), -1 * numYears).getTime(),
-    timeDay.floor(new Date()).getTime(),
-  ];
-}
-
 class TimeSlider extends React.Component {
+
   constructor(props) {
     super(props);
+
     this.state = {
       brushExtent: this.props.defaultBrushExtent,
       firstInputVal: this.props.defaultBrushExtent[0],
       secondInputVal: this.props.defaultBrushExtent[1],
+      spanEnd: this.props.spanEnd,
+      xSpan: [
+        timeYear.offset(this.props.spanEnd, -1 * this.props.xSpan).getTime(),
+        this.props.spanEnd,
+      ],
+      initialParamsChecked: false,
     };
-
-    this.xSpan = spanOfYears(this.props.xSpan);
 
     this.determineNewExtent = this.determineNewExtent.bind(this);
     this.brushDuring = this.brushDuring.bind(this);
     this.brushEnd = this.brushEnd.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
+
   }
 
   determineNewExtent(e, snap = false) {
     let newExtent = e;
+    let newSpan = this.state.xSpan;
+
+    // If someone just clicked on the timeline there might not be an e
     if (e) {
-      // If someone just clicked on the timeline there might not be an e
 
-      // if (snap) {
-      //   // const timeFunc = whichD3TimeFunction(e);
-      //   const timeFunc = timeDay;
-      //   newExtent = [timeFunc.floor(e[0]), timeFunc.ceil(e[1])];
+      // When brushing stops (brushEnd calls with snap=true), snap to "whole time" (drop the decimal part)
+      if (snap) {
+        const timeFunc = timeDay;
+        newExtent = [timeFunc.floor(e[0]).getTime(), timeFunc.ceil(e[1]).getTime()];
+      }
+
+      let selectedRange = timeDay.count(newExtent[0], newExtent[1]);
+      let spanRange = timeDay.count(this.state.xSpan[0], this.state.xSpan[1]);
+      let rangeDiff = spanRange - selectedRange;
+      let rangeOverhead = timeDay.count(newExtent[1], this.props.spanUpperLimit);
+      let rangeUnderhead = timeDay.count(this.props.spanLowerLimit, newExtent[0]);
+
+      if (rangeOverhead <= 0 || rangeUnderhead <= 0) {
+        return {
+          extent: this.state.brushExtent,
+          span: newSpan
+        };
+      }
+
+      // Don't allow ranges bigger or smaller (i.e. negative) than allowed, just reset to "last good" value
+      if (selectedRange > this.props.maxDaysAllowedToQuery || +newExtent[0] >= +newExtent[1]) {
+        console.log(`Date range too big or small. Max range is ${this.props.maxDaysAllowedToQuery} days. Min range is 1 day.`);
+        newExtent = this.state.brushExtent;
+        // no need to change the existing span
+      }
+      // Don't allow dates before or after defined limits
+      else if (+newExtent[0] < +this.props.spanLowerLimit || +newExtent[1] > +this.props.spanUpperLimit) {
+        console.log(`Selected date(s) are out of bounds.`);
+        newExtent = this.state.brushExtent;
+        // no need to change the existing span
+      }
+      // Don't allow date ranges starting before AND ending after the current span
+      else if (+newExtent[0] < +this.state.xSpan[0] && +newExtent[1] > +this.state.xSpan[1]) {
+        newExtent = this.state.brushExtent;
+        // no need to change the existing span
+      }
+      // If only the end date is outside span limit
+      else if (+newExtent[0] > +this.state.xSpan[0] && +newExtent[1] > +this.state.xSpan[1]) {
+        if (+newExtent[1] > +this.props.spanUpperLimit) {
+          newExtent[1] = this.props.spanUpperLimit;
+          newSpan = [
+            timeYear.offset(this.props.spanUpperLimit, -1 * this.props.xSpan).getTime(),
+            this.props.spanUpperLimit,
+          ];
+        }
+        else {
+          if (rangeDiff / 2 <= rangeOverhead) {
+            newSpan = [
+              timeDay.offset(newExtent[0], -1 * (rangeDiff / 2)).getTime(),
+              timeDay.offset(newExtent[1], (rangeDiff / 2)).getTime(),
+            ];
+          }
+          else {
+            newSpan = [
+              timeDay.offset(newExtent[0], -1 * (rangeDiff - rangeOverhead)).getTime(),
+              timeDay.offset(newExtent[1], rangeOverhead).getTime(),
+            ];
+          }
+        }
+      }      
+      // If only the start date is outside span limit
+      else if (+newExtent[0] < +this.state.xSpan[0] && +newExtent[1] < +this.state.xSpan[1]) {
+        if (+newExtent[0] < +this.props.spanLowerLimit) {
+          newExtent[0] = this.props.spanLowerLimit;
+          newSpan = [
+            this.props.spanLowerLimit,
+            timeYear.offset(this.props.spanLowerLimit, this.props.xSpan).getTime(),
+          ];
+        }
+        else {
+          if (rangeDiff / 2 <= rangeUnderhead) {
+            newSpan = [
+              timeDay.offset(newExtent[0], -1 * (rangeDiff / 2)).getTime(),
+              timeDay.offset(newExtent[1], (rangeDiff / 2)).getTime(),
+            ];
+          }
+          else {
+            newSpan = [
+              timeDay.offset(newExtent[0], -1 * rangeUnderhead).getTime(),
+              timeDay.offset(newExtent[1], (rangeDiff - rangeUnderhead)).getTime(),
+            ];
+          }
+        }
+      }
+
+      // Selected date above current span ceiling?
+        // Is selected date above permitted upper limit for span?
+      // if (+newExtent[1] > +this.state.xSpan[1]) {
+      //   if (+newExtent[1] > +this.props.spanUpperLimit) {
+      //     newExtent[1] = this.props.spanUpperLimit;
+      //   }
+      //   newExtent[1] = this.state.xSpan[1];
       // }
+      // Start date selected is before start of current span
+      if (+newExtent[0] < +this.state.xSpan[0]) {
 
-      // Don't let the new extent be outside of our timeline
-      if (+newExtent[1] > +this.xSpan[1]) {
-        newExtent[1] = this.xSpan[1];
+        // Is new start date valid for existing data? (e.g. > 1999-ish)
+        // - if no, just reset to "last good" values as above
+        // If valid, does it create a span larger than our max range? (e.g. over 2 years)
+        // - if yes, set end date and span end = [new start] + [max range]
+        // - if no, keep end date and reset span start/end (leave space before start and after end? like (maxRange - selectedDateRange) / 2)
+
+        // newExtent[0] = this.state.xSpan[0];
       }
-      if (+newExtent[0] < +this.xSpan[0]) {
-        newExtent[0] = this.xSpan[0];
-      }
+      
+
     } else {
       // If there isn't an e value
       newExtent = this.state.brushExtent;
     }
-    return newExtent;
+    return {
+      extent: newExtent,
+      span: newSpan
+    };
   }
 
   brushDuring(e) {
-    const newExtent = this.determineNewExtent(e, false);
+    const newRanges = this.determineNewExtent(e, false);
     this.setState({
-      brushExtent: newExtent,
-      firstInputVal: newExtent[0],
-      secondInputVal: newExtent[1],
+      brushExtent: newRanges.extent,
+      firstInputVal: newRanges.extent[0],
+      secondInputVal: newRanges.extent[1],
     });
   }
 
   brushEnd(e, snap = true) {
-    const newExtent = this.determineNewExtent(e, snap);
-    this.props.onBrushEnd(newExtent);
+    const newRanges = this.determineNewExtent(e, snap);
+    this.props.onBrushEnd(newRanges.extent);
     this.setState({
-      brushExtent: newExtent,
-      firstInputVal: newExtent[0],
-      secondInputVal: newExtent[1],
+      brushExtent: newRanges.extent,
+      firstInputVal: newRanges.extent[0],
+      secondInputVal: newRanges.extent[1],
+      xSpan: newRanges.span,
     });
   }
 
@@ -84,10 +183,23 @@ class TimeSlider extends React.Component {
     ], false);
   }
 
+  componentDidMount() {
+    if (!this.state.initialParamsChecked) {
+      const initialParams = this.determineNewExtent(this.state.defaultBrushExtent, false);
+      this.setState({
+        brushExtent: initialParams.extent,
+        firstInputVal: initialParams.extent[0],
+        secondInputVal: initialParams.extent[1],
+        xSpan: initialParams.span,
+        initialParamsChecked: true,
+      });
+    }
+  }
+
   render() {
     const ticks = timeMonth.range(
-      timeMonth.ceil(this.xSpan[0]),
-      timeMonth.ceil(this.xSpan[1]),
+      timeMonth.ceil(this.state.xSpan[0]),
+      timeMonth.ceil(this.state.xSpan[1]),
     );
     // TODO: Use hover annotation and fake lines to make tooltip
     return (
@@ -175,7 +287,7 @@ class TimeSlider extends React.Component {
             size={[1000, 75]}
             xAccessor={d => d}
             yAccessor={() => 0}
-            xExtent={this.xSpan}
+            xExtent={this.state.xSpan}
             axes={[
               {
                 orient: 'bottom',
@@ -214,8 +326,12 @@ TimeSlider.defaultProps = {
   defaultBrushExtent: [
     timeWeek.offset(timeDay.floor(new Date()), -1).getTime(),
     timeDay.floor(new Date()).getTime(),
-  ], // today and today minus thirty-one days
+  ], 
   onBrushEnd: newExtent => console.log(newExtent),
+  spanEnd: timeDay.floor(new Date()).getTime(),
+  spanUpperLimit: timeDay.floor(new Date()).getTime(),
+  spanLowerLimit: timeDay.floor(new Date(Date.UTC(1999, 6, 1))).getTime(),
+  maxDaysAllowedToQuery: 730,
   xSpan: 2, // in years
 };
 


### PR DESCRIPTION
Refactor TimeSlider and PermitsIndex to:
- allow more flexible input (e.g. outside bounds of given slider span)
- enforce absolute range limits (i.e. Jan 1,  1999 through "today")
- integrate URL params for linking/bookmarking certain ranges
- restore shorter default range for faster querying (2 months)
- add URL param (range=oneYearBack) for DSD use