### PR TITLE
Tweaked API request so the response doesn't time 

### DIFF
--- a/src/app/property/PropertiesByNeighborhood.js
+++ b/src/app/property/PropertiesByNeighborhood.js
@@ -205,9 +205,7 @@ const PropertiesByNeighborhoodGQL = graphql(getPropertiesByNeighborhoodQuery, {
   options: ownProps => ({
     variables: {
       nbrhd_ids: [ownProps.location.query.id.trim()],
-    },
-    fetchPolicy: 'no-cache', 
-
+    }
   }),
 })(PropertiesByNeighborhood);
 

--- a/src/app/property/PropertiesByNeighborhood.js
+++ b/src/app/property/PropertiesByNeighborhood.js
@@ -12,6 +12,7 @@ import Error from '../../shared/Error';
 import expandingRows from '../../shared/react_table_hoc/ExpandingRows';
 import createFilterRenderer from '../../shared/FilterRenderer';
 
+
 const FilterRenderer = createFilterRenderer('Search...');
 
 const dataColumns = [
@@ -131,36 +132,40 @@ PropertiesByNeighborhood.defaultProps = {
   query: { entity: 'address', label: '123 Main street' },
 };
 
+
+
+
+
 const getPropertiesByNeighborhoodQuery = gql`
   query getPropertiesByNeighborhoodQuery($nbrhd_ids: [String]) {
     properties_by_neighborhood (nbrhd_ids: $nbrhd_ids) {
       civic_address_ids
+      acreage
+      tax_exempt
+      building_value
+      property_card_link
+      deed_link
+      appraisal_area
+      owner_address
+      owner
+      market_value
+      tax_value
+      plat_link
+      appraised_value
+      land_value
+      zoning
+      appraisal_area
+      is_in_city
       property_civic_address_id
       pinnum
       address
       property_address
-      city
-      property_city
-      is_in_city
       zipcode
       property_zipcode
-      tax_exempt
       neighborhood
       appraisal_area
-      acreage
-      zoning
-      deed_link
-      property_card_link
-      plat_link
       latitude
       longitude
-      building_value
-      land_value
-      appraised_value
-      tax_value
-      market_value
-      owner
-      owner_address
       polygons {
         outer {
           points {
@@ -201,6 +206,8 @@ const PropertiesByNeighborhoodGQL = graphql(getPropertiesByNeighborhoodQuery, {
     variables: {
       nbrhd_ids: [ownProps.location.query.id.trim()],
     },
+    fetchPolicy: 'no-cache', 
+
   }),
 })(PropertiesByNeighborhood);
 


### PR DESCRIPTION
So I looked into fixing the "too big api response" issue a couple different ways, like seeing if I could remove the __typename fields from the request, etc. All of them felt like weird bad one-off solutions, but then I took another look at the request, and turns out a few of the attributes aren't actually needed, so I just deleted the unused attributes and now the api request is small enough to work. 

(I originally delete a lot more, then had to add them back in, which is why the code looks the way it does)

I made a note of this issue in the simplicity folder so we can keep it in mind for the refactor.