### PR TITLE
better error handling for addresses

### DIFF
--- a/src/app/address/Address.jsx
+++ b/src/app/address/Address.jsx
@@ -198,6 +198,9 @@ const Address = (props) => (
 			};
 
 			const addressData = data.addresses[0];
+			if (!addressData) {
+				return <Error className="text-black" message="Address not found." />;
+			}
 			const mapData = [
 				Object.assign(
 					{},

--- a/src/shared/Error.js
+++ b/src/shared/Error.js
@@ -1,27 +1,33 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import moment from 'moment';
+import React from "react";
+import PropTypes from "prop-types";
+import moment from "moment";
 
-const Error = props => (
-  <div className="row">
-    <div className="col-sm-12">
-      <div className="alert alert-danger alert-sm">
-        <p>
-          There was an error reaching the server. You may report issues using <a href="https://docs.google.com/a/ashevillenc.gov/forms/d/e/1FAIpQLSdjNwOmoDY3PjQOVreeSL07zgI8otIIPWjY7BnejWMAjci8-w/viewform?c=0&w=1" target="_blank" style={{ color: '#fff', textDecoration: 'underline' }}>this form</a>.
-        </p>
-        <p>
-          Time: {moment().format('M/DD/YYYY HH:mm:ss Z')} UTC
-        </p>
-        <p>
-          <span>Error details: </span>{props.message}
-        </p>
-      </div>
-    </div>
-  </div>
+const Error = (props) => (
+	<div className="row">
+		<div className="col-sm-12">
+			<div className="alert alert-danger alert-sm">
+				<p>
+					There was an error reaching the server. You may report issues using{" "}
+					<a
+						href="https://docs.google.com/a/ashevillenc.gov/forms/d/e/1FAIpQLSdjNwOmoDY3PjQOVreeSL07zgI8otIIPWjY7BnejWMAjci8-w/viewform?c=0&w=1"
+						target="_blank"
+					>
+						this form
+					</a>
+					.
+				</p>
+				<p>Time: {moment().format("M/DD/YYYY HH:mm:ss Z")} UTC</p>
+				<p>
+					<span>Error details: </span>
+					{props.message}
+				</p>
+			</div>
+		</div>
+	</div>
 );
 
 Error.propTypes = {
-  message: PropTypes.string,
+	message: PropTypes.string,
 };
 
 export default Error;


### PR DESCRIPTION
Added error handling to address pages, removed a little bit of default styling that made the link white everywhere. I tried to check this to make sure the color change would work everywhere the error component is used; as far as I can tell, the styling change works everywhere.