### PR TITLE
Adding "No Results" styling

### DIFF
--- a/src/app/address/Address.jsx
+++ b/src/app/address/Address.jsx
@@ -199,7 +199,7 @@ const Address = (props) => (
 
 			const addressData = data.addresses[0];
 			if (!addressData) {
-				return <Error className="text-black" message="Address not found." />;
+				return <div className="alert alert-info">No results found</div>;
 			}
 			const mapData = [
 				Object.assign(

--- a/src/app/property/Property.jsx
+++ b/src/app/property/Property.jsx
@@ -129,6 +129,9 @@ const Property = (props) => {
 	if (props.data.error) {
 		return <Error message={props.data.error.message} />;
 	}
+	if (!props.data.loading && !props.data.properties.civic_address_ids) {
+		return <div className="alert alert-info">No results found</div>;
+	}
 
 	const propertyData = props.inTable ? props.data : props.data.properties[0];
 	const dataForAddressesTable = [];

--- a/src/tw/tw-input.css
+++ b/src/tw/tw-input.css
@@ -14,9 +14,10 @@
     @apply p-4 bg-light rounded shadow w-fit min-w-[200px] max-w-[600px] my-2 mx-auto flex justify-center;
   }
 
-  .alert-info {
+  /* Alert info exists, but keeping it as bg-light for now */
+  /* .alert-info {
     @apply bg-light; 
-  }
+  } */
 
   .alert-warning {
     @apply bg-warning;

--- a/src/tw/tw-input.css
+++ b/src/tw/tw-input.css
@@ -10,6 +10,22 @@
     @apply h-full w-full m-0 p-0;
   }
 
+  .alert {
+    @apply p-4 bg-light rounded shadow w-fit min-w-[200px] max-w-[600px] my-2 mx-auto flex justify-center;
+  }
+
+  .alert-info {
+    @apply bg-light; 
+  }
+
+  .alert-warning {
+    @apply bg-warning;
+  }
+
+  .alert-danger {
+    @apply bg-danger;
+  }
+
   .skip-nav-link {
     @apply absolute -left-[9999px] -top-[9999px] z-[9999] bg-primary px-6 py-3 text-white font-semibold shadow-lg focus:left-0 focus:top-0;
   }

--- a/src/tw/tw-output.css
+++ b/src/tw/tw-output.css
@@ -643,10 +643,11 @@ html,
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
-.alert-info {
-  --tw-bg-opacity: 1;
-  background-color: rgb(246 252 255 / var(--tw-bg-opacity, 1));
-}
+/* Alert info exists, but keeping it as bg-light for now */
+
+/* .alert-info {
+    @apply bg-light; 
+  } */
 
 .alert-warning {
   --tw-bg-opacity: 1;

--- a/src/tw/tw-output.css
+++ b/src/tw/tw-output.css
@@ -622,6 +622,42 @@ html,
   padding: 0px;
 }
 
+.alert {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+  margin-left: auto;
+  margin-right: auto;
+  display: flex;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  min-width: 200px;
+  max-width: 600px;
+  justify-content: center;
+  border-radius: 0.25rem;
+  --tw-bg-opacity: 1;
+  background-color: rgb(246 252 255 / var(--tw-bg-opacity, 1));
+  padding: 1rem;
+  --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.alert-info {
+  --tw-bg-opacity: 1;
+  background-color: rgb(246 252 255 / var(--tw-bg-opacity, 1));
+}
+
+.alert-warning {
+  --tw-bg-opacity: 1;
+  background-color: rgb(243 156 18 / var(--tw-bg-opacity, 1));
+}
+
+.alert-danger {
+  --tw-bg-opacity: 1;
+  background-color: rgb(231 76 60 / var(--tw-bg-opacity, 1));
+}
+
 .skip-nav-link {
   position: absolute;
   left: -9999px;
@@ -2154,11 +2190,6 @@ details[open] summary span.bi {
 .text-white {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity, 1));
-}
-
-.underline {
-  -webkit-text-decoration-line: underline;
-          text-decoration-line: underline;
 }
 
 .no-underline {


### PR DESCRIPTION
We are still using the classes alert and alert-info, alert-warning, etc, throughout simplicity. I defined these classes in the tailwind input file so they look a bit nicer.

I kept alert-info commented in the input file to remind us that it exists in case we want to change it later. I tried different background colors for alert-info, but all the shades of blue make it read as a button to me, so I went with the light background (default alert bg) instead.

Added "No results" to display for addresses under certain conditions.

Edit: I added "No results" for property files too